### PR TITLE
docs: editorconfig 파일 추가

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+charset = utf-8


### PR DESCRIPTION
editorconfig 파일 추가
utf-8 자동 인코딩 (단, vscode에서 확장 필요하다는 데 이건 나중에 생각해도 되는 문제임)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 프로젝트에 `.editorconfig` 파일이 추가되어 모든 파일에 UTF-8 문자셋이 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->