### PR TITLE
refactor: 노트북공격 소리 타이밍 조정

### DIFF
--- a/Assets/01.Scripts/Player/PlayerAttack_MK.cs
+++ b/Assets/01.Scripts/Player/PlayerAttack_MK.cs
@@ -76,7 +76,7 @@ public class PlayerAttack_MK : MonoBehaviour
             SmashWeapon();
             animator.SetTrigger("Smash");
 
-            AudioManager.Instance.PlayPlayerAttack(2);
+            StartCoroutine(SmashAudio(0.8f));
 
             StartCoroutine(SmashAttack());
         }
@@ -167,7 +167,11 @@ public class PlayerAttack_MK : MonoBehaviour
         isSmashing = false;
     }
 
-
+    IEnumerator SmashAudio(float duration)
+    {
+        yield return new WaitForSeconds(duration);
+        AudioManager.Instance.PlayPlayerAttack(2);
+    }
     private void SmashWeapon()
     {
         isSmashing = true;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 스매시 공격 시 사운드 효과가 즉시 재생되지 않고, 0.8초 후에 재생되도록 타이밍이 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->