### PR TITLE
[FEAT] 스킬 수치 조정

### DIFF
--- a/Assets/01.Scripts/Enemy/Boss/01.Boss/BossSkill1.cs
+++ b/Assets/01.Scripts/Enemy/Boss/01.Boss/BossSkill1.cs
@@ -62,6 +62,7 @@ public class BossSkill1 : MonoBehaviour
         }
 
         Destroy(lightning, 2f); // 2초 후 자동 삭제 (VFX 이펙트의 재생 시간과 맞춰야 합니다)
+        yield return new WaitForSeconds(1.2f);
 
         // 딜 적용
         // Physics.OverlapSphere는 현재 'transform.position' (보스의 현재 위치)를 기준으로 합니다.

--- a/Assets/01.Scripts/Enemy/Boss/01.Boss/BossSkill2.cs
+++ b/Assets/01.Scripts/Enemy/Boss/01.Boss/BossSkill2.cs
@@ -8,7 +8,7 @@ public class BossSkill2 : MonoBehaviour
     public GameObject laserPrefab;
     public float laserDuration = 3f;
     public float laserLength = 20f;
-    public float damagePerSecond = 50f;
+    public float damagePerSecond = 20f;
     public LayerMask hitLayerMask;
 
     private GameObject laser;

--- a/Assets/02.Prefabs/Enemy/Boss/01.Boss/Rackboss.prefab
+++ b/Assets/02.Prefabs/Enemy/Boss/01.Boss/Rackboss.prefab
@@ -2956,6 +2956,10 @@ PrefabInstance:
       propertyPath: firePoint
       value: 
       objectReference: {fileID: 4126178550045650629}
+    - target: {fileID: 4274637635886162931, guid: 8b4d289166a4df149a6ada5637515995, type: 3}
+      propertyPath: damagePerSecond
+      value: 20
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Assets/03.Scenes/MapScene.unity
+++ b/Assets/03.Scenes/MapScene.unity
@@ -40689,7 +40689,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1017606091530846216, guid: c5be39b879c83f54d9bbfebe68c809be, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -5.434735
+      value: -4.6
       objectReference: {fileID: 0}
     - target: {fileID: 1017606091530846216, guid: c5be39b879c83f54d9bbfebe68c809be, type: 3}
       propertyPath: m_LocalPosition.y

--- a/Assets/04.ScriptableObjects/Enemy/Boss/01.Boss/Boss1AttackInfos.asset
+++ b/Assets/04.ScriptableObjects/Enemy/Boss/01.Boss/Boss1AttackInfos.asset
@@ -14,6 +14,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   damage: 20
   attackSpeed: 1
-  attackRange: 2
+  attackRange: 3
   attackSound: {fileID: 0}
   attackModel: {fileID: 0}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 보스의 번개 공격이 시전된 후 1.2초 지연 후 피해가 적용되어, 시각 효과와 피해 타이밍이 일치하도록 개선되었습니다.
  * 보스의 레이저 스킬 초당 피해량이 50에서 20으로 감소하여 난이도가 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->