### PR TITLE
[FIX] 단서보관함 열었다 끄면 체력이 차는 버그 수정

### DIFF
--- a/Assets/01.Scripts/Player/HealthBar_ES.cs
+++ b/Assets/01.Scripts/Player/HealthBar_ES.cs
@@ -13,7 +13,6 @@ public class HealthBar_ES : MonoBehaviour
     {
         if (maxHealth != null)
         {
-            currentHealth = maxHealth;
             UpdateHealthBar();
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 플레이어의 체력바가 활성화될 때 현재 체력 값이 초기화되지 않고 기존 값을 유지하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->